### PR TITLE
Configure truststore in static init phase of the build chain

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -233,6 +233,13 @@ class KeycloakProcessor {
         recorder.configureProfile(profile.getName(), profile.getFeatures());
     }
 
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep
+    @Consume(ConfigBuildItem.class)
+    void configureTruststore(KeycloakRecorder recorder) {
+        recorder.configureTruststore();
+    }
+
     /**
      * Check whether JDBC driver is present for the specified DB
      *

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -68,6 +68,10 @@ public class KeycloakRecorder {
         Profile.init(profileName, features);
     }
 
+    public void configureTruststore() {
+        TruststoreBuilder.setSystemTruststore();
+    }
+
     public void configureLiquibase(Map<String, List<String>> services) {
         ServiceLocator locator = Scope.getCurrentScope().getServiceLocator();
         if (locator instanceof FastServiceLocator)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -18,7 +18,6 @@
 package org.keycloak.quarkus.runtime.cli.command;
 
 import org.keycloak.quarkus.runtime.KeycloakMain;
-import org.keycloak.quarkus.runtime.TruststoreBuilder;
 import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 
 import picocli.CommandLine;
@@ -31,7 +30,6 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
         doBeforeRun();
         CommandLine cmd = spec.commandLine();
         validateNonCliConfig();
-        TruststoreBuilder.setSystemTruststore();
         KeycloakMain.start((ExecutionExceptionHandler) cmd.getExecutionExceptionHandler(), cmd.getErr(), cmd.getParseResult().originalArgs().toArray(new String[0]));
     }
 


### PR DESCRIPTION
We could leverage the Quarkus bytecode recording[1] for this purpose. We will also prevent any race condition in the build chain execution as we require the config source initialized when we set truststores.

@shawkins @vmuzikar WDYT? 

[1] https://quarkus.io/guides/writing-extensions#bytecode-recording