### PR TITLE
Follow upgrading guide for Quarkus 3.31.0

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -130,17 +130,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-component</artifactId>
+            <artifactId>quarkus-junit-component</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -178,6 +178,7 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.build.version}</version>
+                <extensions>true</extensions>
             </plugin>
             </plugins>
         </pluginManagement>
@@ -186,6 +187,7 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.build.version}</version>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                     <goals>

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -68,6 +68,7 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.build.version}</version>
+                <extensions>true</extensions>
                 <configuration>
                     <finalName>keycloak</finalName>
                     <systemProperties>

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -77,11 +77,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Followed the upgrading guide: 
- JUnit 5 modules renamed -> https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#junit-6-gear-white_check_mark
- ~~Surefire config for JDK 25 preparation~~ Does not work for our tests now (not sure why) -> https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#surefirefailsafe-configuration-gear-white_check_mark
- Add extensions marker -> https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#extensions-gear-white_check_mark